### PR TITLE
feat: list & disable api keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,5 @@ go.work
 
 fewsatscli
 fewsatscli-v*
-.env
+.env*
 .DS_Store

--- a/apikeys/apikeys.go
+++ b/apikeys/apikeys.go
@@ -10,6 +10,8 @@ func Command() *cli.Command {
 		Usage: "Interact with api keys.",
 		Subcommands: []*cli.Command{
 			createCommand,
+			listCommand,
+			disableCommand,
 		},
 	}
 }

--- a/apikeys/disable.go
+++ b/apikeys/disable.go
@@ -1,0 +1,38 @@
+package apikeys
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/fewsats/fewsatscli/client"
+	"github.com/urfave/cli/v2"
+)
+
+var disableCommand = &cli.Command{
+	Name:      "disable",
+	Usage:     "Disable an API key.",
+	ArgsUsage: "[api_key_id]",
+	Action:    disableAPIKey,
+}
+
+func disableAPIKey(c *cli.Context) error {
+	if c.Args().Len() < 1 {
+		return cli.Exit("API key ID is required", 1)
+	}
+	apiKeyID := c.Args().Get(0)
+
+	client, err := client.NewHTTPClient()
+	if err != nil {
+		return cli.Exit("Failed to create HTTP client", 1)
+	}
+
+	endpoint := fmt.Sprintf("/v0/auth/apikeys/%s/disable", apiKeyID)
+	resp, err := client.ExecuteRequest(http.MethodPost, endpoint, nil)
+	if err != nil {
+		return cli.Exit("Failed to disable API key", 1)
+	}
+	defer resp.Body.Close()
+
+	fmt.Println("API key disabled successfully")
+	return nil
+}

--- a/apikeys/list.go
+++ b/apikeys/list.go
@@ -1,0 +1,81 @@
+package apikeys
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"text/tabwriter"
+	"time" // Added to support time.Time in APIKey struct
+
+	"github.com/fewsats/fewsatscli/client"
+	"github.com/fewsats/fewsatscli/config"
+	"github.com/urfave/cli/v2"
+)
+
+// APIKey represents an API key that can be used to authenticate requests as
+// a given user.
+type APIKey struct {
+	ID        uint64
+	HiddenKey string
+	ExpiresAt *time.Time
+}
+
+var listCommand = &cli.Command{
+	Name:   "list",
+	Usage:  "List all API keys.",
+	Action: listAPIKeys,
+}
+
+func printKeys(keys []APIKey) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', tabwriter.Debug)
+	fmt.Fprintln(w, "ID\t Key\t ExpiresAt")
+	for _, key := range keys {
+		fmt.Fprintf(w, "%d\t %s\t %s\n", key.ID, key.HiddenKey, key.ExpiresAt)
+	}
+	w.Flush()
+}
+
+func listAPIKeys(c *cli.Context) error {
+	cfg, err := config.GetConfig()
+	if err != nil {
+		slog.Debug("Failed to get config.", "error", err)
+		return cli.Exit("Failed to get config.", 1)
+	}
+
+	client, err := client.NewHTTPClient()
+	if err != nil {
+		slog.Debug("Failed to create HTTP client.", "error", err)
+		return cli.Exit("Failed to create HTTP client.", 1)
+	}
+
+	// Try using existing API key
+	if cfg.APIKey != "" {
+		resp, err := client.ExecuteRequest(http.MethodGet, "/v0/auth/apikeys?limit=100", nil)
+		if err != nil {
+			slog.Debug("Failed to execute request with API key.", "error", err)
+			return cli.Exit("Failed to execute request.", 1)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return cli.Exit(fmt.Sprintf("Failed request status code: %d", resp.StatusCode), 1)
+		}
+
+		var response struct {
+			Keys       []APIKey `json:"keys"`
+			TotalCount int      `json:"total_count"`
+		}
+		err = json.NewDecoder(resp.Body).Decode(&response)
+		if err != nil {
+			return cli.Exit("Failed to decode API keys.", 1)
+		}
+
+		printKeys(response.Keys)
+		return nil
+
+	}
+	return nil
+
+}


### PR DESCRIPTION
corresponding CLI updates for platform new features: https://github.com/Fewsats/platform/pull/12

What's missing:
* Pagination is not handled. I suggest we set the server to a high default limit (say 100) for the time being. Or do you think we should do it already? I just didn't feel pagination is too useful here, so I wanted to discuss before spending time on it.
* Currently both the list & disable keys use only `apiKey` authentication. Should I add the login based authentication too? I wasn't too sure as you can always create a new key and then use that to access those endpoints so it's kind of duplicated flows.