### PR TITLE
Sql store

### DIFF
--- a/account/account.go
+++ b/account/account.go
@@ -10,6 +10,7 @@ func Command() *cli.Command {
 		Usage: "Interact with your account.",
 		Subcommands: []*cli.Command{
 			signUpCommand,
+			loginCommand,
 		},
 	}
 }

--- a/account/login.go
+++ b/account/login.go
@@ -1,0 +1,137 @@
+package account
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/fewsats/fewsatscli/apikeys"
+	"github.com/fewsats/fewsatscli/client"
+	"github.com/urfave/cli/v2"
+	"golang.org/x/term"
+)
+
+const (
+	// loginPath is the path to the login endpoint.
+	loginPath = "/v0/auth/login"
+)
+
+// LoginRequest is the request body for the login endpoint.
+type LoginRequest struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+var loginCommand = &cli.Command{
+	Name:   "login",
+	Usage:  "Log into your account.",
+	Flags:  []cli.Flag{},
+	Action: LoginCLI,
+}
+
+// LoginCLI handles the CLI login interaction.
+func LoginCLI(c *cli.Context) error {
+	fmt.Print("Enter email: ")
+	var email string
+	_, err := fmt.Scanln(&email)
+	if err != nil {
+		return cli.Exit("Failed to read email.", 1)
+	}
+
+	fmt.Print("Enter password: ")
+	bytePassword, err := term.ReadPassword(int(syscall.Stdin))
+	if err != nil {
+		return cli.Exit("Failed to read password.", 1)
+	}
+	password := strings.TrimSpace(string(bytePassword))
+
+	// Newline for the next prompt.
+	fmt.Println()
+
+	// Perform the login using the email and password
+	sessionCookie, err := Login(email, password)
+	if err != nil {
+		return cli.Exit("Login failed: "+err.Error(), 1)
+	}
+
+	fmt.Println("Login successful. Session:", sessionCookie.Value)
+	return nil
+}
+
+// Login to the fewsats API and return the session cookie
+func Login(email, password string) (*http.Cookie, error) {
+	method := http.MethodPost
+	client, err := client.NewHTTPClient()
+	if err != nil {
+		slog.Debug(
+			"Failed to create http client.",
+			"error", err,
+		)
+
+		return nil, cli.Exit("Failed to create http client.", 1)
+	}
+
+	loginReqBody, err := json.Marshal(&LoginRequest{
+		Email:    email,
+		Password: password,
+	})
+	if err != nil {
+		slog.Debug(
+			"Failed to marshal login request body.",
+			"error", err,
+		)
+
+		return nil, cli.Exit("Failed to marshal login request body.", 1)
+	}
+
+	resp, err := client.ExecuteRequest(method, loginPath, loginReqBody)
+	if err != nil {
+		slog.Debug(
+			"Failed to execute login request.",
+			"error", err,
+		)
+
+		return nil, cli.Exit("Failed to execute login request.", 1)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		slog.Debug(
+			"Login request failed.",
+			"status_code", resp.StatusCode,
+		)
+
+		return nil, cli.Exit("Login request failed.", 1)
+	}
+
+	// Get the session cookie from the response
+	var sessionCookie *http.Cookie
+	for _, cookie := range resp.Cookies() {
+		if cookie.Name == "fewsats_session" {
+			sessionCookie = cookie
+			break
+		}
+	}
+
+	if sessionCookie == nil {
+		slog.Debug("Session cookie not found.")
+		return nil, cli.Exit("Session cookie not found.", 1)
+	}
+
+	apiKey, expiresAt, err := apikeys.CreateAPIKey(24*7*4*time.Hour, sessionCookie)
+	if err != nil {
+		slog.Debug("Failed to create API key on login.", "error", err)
+		return nil, cli.Exit("Failed to create API key on login.", 1)
+	}
+
+	fmt.Println("API key created on login.")
+	fmt.Println("API key:", apiKey)
+	fmt.Println("Expires at:", expiresAt)
+
+	fmt.Println("Login successful.", sessionCookie.Value)
+	return sessionCookie, nil
+}

--- a/account/login.go
+++ b/account/login.go
@@ -53,12 +53,12 @@ func LoginCLI(c *cli.Context) error {
 	fmt.Println()
 
 	// Perform the login using the email and password
-	sessionCookie, err := Login(email, password)
+	_, err = Login(email, password)
 	if err != nil {
 		return cli.Exit("Login failed: "+err.Error(), 1)
 	}
 
-	fmt.Println("Login successful. Session:", sessionCookie.Value)
+	fmt.Println("Login successful.")
 	return nil
 }
 
@@ -128,10 +128,9 @@ func Login(email, password string) (*http.Cookie, error) {
 		return nil, cli.Exit("Failed to create API key on login.", 1)
 	}
 
-	fmt.Println("API key created on login.")
-	fmt.Println("API key:", apiKey)
-	fmt.Println("Expires at:", expiresAt)
+	slog.Debug("API key created on login.")
+	slog.Debug("API key:", "apiKey", apiKey)
+	slog.Debug("Expires at:", "expiresAt", expiresAt)
 
-	fmt.Println("Login successful.", sessionCookie.Value)
 	return sessionCookie, nil
 }

--- a/apikeys/create.go
+++ b/apikeys/create.go
@@ -1,27 +1,20 @@
 package apikeys
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
-	"strings"
-	"syscall"
 	"time"
 
 	"github.com/fewsats/fewsatscli/client"
-	"github.com/fewsats/fewsatscli/config"
-	"golang.org/x/term"
+	"github.com/fewsats/fewsatscli/store"
 
 	"github.com/urfave/cli/v2"
 )
 
 const (
-	// loginPath is the path to the login endpoint.
-	loginPath = "/v0/auth/login"
-
-	// apikeys is the path to the create/list api keys endpoint.
+	// apikeysPath is the path to the create/list api keys endpoint.
 	apikeysPath = "/v0/auth/apikey"
 )
 
@@ -40,12 +33,6 @@ var createCommand = &cli.Command{
 	Action: newApiKey,
 }
 
-// LoginRequest is the request body for the login endpoint.
-type LoginRequest struct {
-	Email    string `json:"email"`
-	Password string `json:"password"`
-}
-
 // CreateAPIKeyRequest is the request body for the create api key endpoint.
 type CreateAPIKeyRequest struct {
 	Duration time.Duration `json:"duration"`
@@ -57,216 +44,65 @@ type CreateAPIKeyResponse struct {
 	ExpiresAt *time.Time `json:"expires_at"`
 }
 
-// newApiKey creates a new api key.
-func newApiKey(c *cli.Context) error {
-	cfg, err := config.GetConfig()
-	if err != nil {
-		slog.Debug(
-			"Failed to get config.",
-			"error", err,
-		)
-
-		return cli.Exit("Failed to marshal JSON body.", 1)
-	}
-
-	duration := c.Duration("duration")
-
+// CreateAPIKey is an exported function to create an API key.
+func CreateAPIKey(duration time.Duration, sessionCookie *http.Cookie) (string, *time.Time, error) {
 	req := &CreateAPIKeyRequest{Duration: duration}
 	reqBody, err := json.Marshal(req)
 	if err != nil {
-		slog.Debug(
-			"Failed to marshal JSON body.",
-			"error", err,
-		)
-
-		return cli.Exit("Failed to marshal JSON body.", 1)
+		slog.Debug("Failed to marshal JSON body.", "error", err)
+		return "", nil, err
 	}
 
-	method := http.MethodPost
 	client, err := client.NewHTTPClient()
 	if err != nil {
-		slog.Debug(
-			"Failed to create http client.",
-			"error", err,
-		)
-
-		return cli.Exit("Failed to create http client.", 1)
+		slog.Debug("Failed to create http client.", "error", err)
+		return "", nil, err
 	}
 
-	// If there is an API key in the config, use it to create a new API key.
-	if cfg.APIKey != "" {
-		resp, err := client.ExecuteRequest(method, apikeysPath, reqBody)
-		if err != nil {
-			slog.Debug(
-				"Failed to execute request.",
-				"error", err,
-			)
-
-			return cli.Exit("Failed to execute request.", 1)
-		}
-
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusCreated {
-			slog.Debug(
-				"Request failed",
-				"status_code", resp.StatusCode,
-			)
-
-			return cli.Exit("Request failed.", 1)
-		}
-
-		var respData CreateAPIKeyResponse
-		err = json.NewDecoder(resp.Body).Decode(&respData)
-		if err != nil {
-			slog.Debug(
-				"Failed to decode response body.",
-				"error", err,
-			)
-
-			return cli.Exit("Failed to decode response body.", 1)
-		}
-
-		fmt.Println("API key created.")
-		fmt.Println("API key:", respData.APIKey)
-		fmt.Println("Expires at:", respData.ExpiresAt)
-
-		return nil
+	if sessionCookie != nil {
+		client.SetSessionCookie(sessionCookie)
 	}
 
-	// If there is no API key in the config, we will get the user/password from
-	// the user and create a new API key using a cookie session.
-	fmt.Print("Login with your user account to create a new API key.\n")
-
-	fmt.Print("Enter email: ")
-	var email string
-	_, err = fmt.Scanln(&email)
+	resp, err := client.ExecuteRequest(http.MethodPost, apikeysPath, reqBody)
 	if err != nil {
-		slog.Debug(
-			"Failed to read email.",
-			"error", err,
-		)
-
-		return cli.Exit("Failed to read email.", 1)
-	}
-
-	fmt.Print("Enter password: ")
-	bytePassword, err := term.ReadPassword(int(syscall.Stdin))
-	if err != nil {
-		slog.Debug(
-			"Failed to read password.",
-			"error", err,
-		)
-
-		return cli.Exit("Failed to read password.", 1)
-	}
-
-	// Trim newline from the input
-	email = strings.TrimSpace(email)
-	password := strings.TrimSpace(string(bytePassword))
-
-	// Newline for the next prompt.
-	fmt.Println()
-
-	loginReqBody, err := json.Marshal(&LoginRequest{
-		Email:    email,
-		Password: password,
-	})
-	if err != nil {
-		slog.Debug(
-			"Failed to marshal login request body.",
-			"error", err,
-		)
-
-		return cli.Exit("Failed to marshal login request body.", 1)
-	}
-
-	resp, err := client.ExecuteRequest(method, loginPath, loginReqBody)
-	if err != nil {
-		slog.Debug(
-			"Failed to execute login request.",
-			"error", err,
-		)
-
-		return cli.Exit("Failed to execute login request.", 1)
+		slog.Debug("Failed to execute request.", "error", err)
+		return "", nil, err
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		slog.Debug(
-			"Login request failed.",
-			"status_code", resp.StatusCode,
-		)
-
-		return cli.Exit("Login request failed.", 1)
+	if resp.StatusCode != http.StatusCreated {
+		return "", nil, fmt.Errorf("request failed with status code: %d", resp.StatusCode)
 	}
 
-	// Get the session cookie from the response
-	var sessionCookie *http.Cookie
-	for _, cookie := range resp.Cookies() {
-		if cookie.Name == "fewsats_session" {
-			sessionCookie = cookie
-			break
-		}
-	}
-
-	if sessionCookie == nil {
-		slog.Debug("Session cookie not found.")
-		return cli.Exit("Session cookie not found.", 1)
-	}
-
-	// Create a new request to create an API key
-	httpReq, err := http.NewRequest(
-		http.MethodPost, cfg.Domain+apikeysPath, bytes.NewBuffer(reqBody),
-	)
-	if err != nil {
-		slog.Debug(
-			"Failed to create request.",
-			"error", err,
-		)
-
-		return cli.Exit("Failed to create request.", 1)
-	}
-
-	// Add the session cookie to the request
-	httpReq.AddCookie(sessionCookie)
-
-	// Send the request
-	httpResp, err := http.DefaultClient.Do(httpReq)
-	if err != nil {
-		slog.Debug(
-			"Failed to execute request.",
-			"error", err,
-		)
-
-		return cli.Exit("Failed to execute request.", 1)
-	}
-
-	// Check the response
-	if httpResp.StatusCode != http.StatusCreated {
-		slog.Debug(
-			"Request failed.",
-			"status_code", resp.StatusCode,
-		)
-
-		return cli.Exit("Request failed.", 1)
-	}
-
-	// Parse the response body
 	var respData CreateAPIKeyResponse
-	err = json.NewDecoder(httpResp.Body).Decode(&respData)
+	err = json.NewDecoder(resp.Body).Decode(&respData)
 	if err != nil {
-		slog.Debug(
-			"Failed to decode response body.",
-			"error", err,
-		)
+		slog.Debug("Failed to decode response body.", "error", err)
+		return "", nil, err
+	}
 
-		return cli.Exit("Failed to decode response body.", 1)
+	// Store the API key in the database
+	store := store.GetStore()
+	_, err = store.InsertAPIKey(respData.APIKey, *respData.ExpiresAt)
+	if err != nil {
+		slog.Debug("Failed to insert API key into database.", "error", err)
+		return "", nil, err
+	}
+
+	return respData.APIKey, respData.ExpiresAt, nil
+}
+
+// newApiKey creates a new api key.
+func newApiKey(c *cli.Context) error {
+	duration := c.Duration("duration")
+	apiKey, expiresAt, err := CreateAPIKey(duration, nil)
+	if err != nil {
+		return cli.Exit(err.Error(), 1)
 	}
 
 	fmt.Println("API key created.")
-	fmt.Println("API key:", respData.APIKey)
-	fmt.Println("Expires at:", respData.ExpiresAt)
+	fmt.Println("API key:", apiKey)
+	fmt.Println("Expires at:", expiresAt)
 
 	return nil
 }

--- a/apikeys/disable.go
+++ b/apikeys/disable.go
@@ -16,6 +16,11 @@ var disableCommand = &cli.Command{
 }
 
 func disableAPIKey(c *cli.Context) error {
+	err := client.RequiresLogin()
+	if err != nil {
+		return cli.Exit("You need to log in to run this command.", 1)
+	}
+
 	if c.Args().Len() < 1 {
 		return cli.Exit("API key ID is required", 1)
 	}

--- a/apikeys/list.go
+++ b/apikeys/list.go
@@ -7,20 +7,12 @@ import (
 	"net/http"
 	"os"
 	"text/tabwriter"
-	"time" // Added to support time.Time in APIKey struct
 
+	// Added to support time.Time in APIKey struct
 	"github.com/fewsats/fewsatscli/client"
-	"github.com/fewsats/fewsatscli/config"
+	"github.com/fewsats/fewsatscli/store"
 	"github.com/urfave/cli/v2"
 )
-
-// APIKey represents an API key that can be used to authenticate requests as
-// a given user.
-type APIKey struct {
-	ID        uint64
-	HiddenKey string
-	ExpiresAt *time.Time
-}
 
 var listCommand = &cli.Command{
 	Name:   "list",
@@ -28,7 +20,7 @@ var listCommand = &cli.Command{
 	Action: listAPIKeys,
 }
 
-func printKeys(keys []APIKey) {
+func printKeys(keys []store.APIKey) {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', tabwriter.Debug)
 	fmt.Fprintln(w, "ID\t Key\t ExpiresAt")
 	for _, key := range keys {
@@ -38,12 +30,6 @@ func printKeys(keys []APIKey) {
 }
 
 func listAPIKeys(c *cli.Context) error {
-	cfg, err := config.GetConfig()
-	if err != nil {
-		slog.Debug("Failed to get config.", "error", err)
-		return cli.Exit("Failed to get config.", 1)
-	}
-
 	client, err := client.NewHTTPClient()
 	if err != nil {
 		slog.Debug("Failed to create HTTP client.", "error", err)
@@ -51,31 +37,27 @@ func listAPIKeys(c *cli.Context) error {
 	}
 
 	// Try using existing API key
-	if cfg.APIKey != "" {
-		resp, err := client.ExecuteRequest(http.MethodGet, "/v0/auth/apikeys?limit=100", nil)
-		if err != nil {
-			slog.Debug("Failed to execute request with API key.", "error", err)
-			return cli.Exit("Failed to execute request.", 1)
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK {
-			return cli.Exit(fmt.Sprintf("Failed request status code: %d", resp.StatusCode), 1)
-		}
-
-		var response struct {
-			Keys       []APIKey `json:"keys"`
-			TotalCount int      `json:"total_count"`
-		}
-		err = json.NewDecoder(resp.Body).Decode(&response)
-		if err != nil {
-			return cli.Exit("Failed to decode API keys.", 1)
-		}
-
-		printKeys(response.Keys)
-		return nil
-
+	resp, err := client.ExecuteRequest(http.MethodGet, "/v0/auth/apikeys?limit=100", nil)
+	if err != nil {
+		slog.Debug("Failed to execute request with API key.", "error", err)
+		return cli.Exit("Failed to execute request.", 1)
 	}
-	return nil
+	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		return cli.Exit(fmt.Sprintf("Failed request status code: %d", resp.StatusCode), 1)
+	}
+
+	var response struct {
+		Keys       []store.APIKey `json:"keys"`
+		TotalCount int            `json:"total_count"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&response)
+	if err != nil {
+		return cli.Exit("Failed to decode API keys.", 1)
+	}
+
+	printKeys(response.Keys)
+
+	return nil
 }

--- a/client/client.go
+++ b/client/client.go
@@ -60,13 +60,17 @@ func (c *HttpClient) ExecuteRequest(method, path string,
 	}
 
 	// do not require auth for signup / login
-	requireAuth := !strings.Contains(path, "/signup") && !strings.Contains(path, "/login")
+	requireAuth := !strings.Contains(path, "/signup") &&
+		!strings.Contains(path, "/login")
+
 	switch {
 	case c.apiKey != "":
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.apiKey))
 	case c.sessionCookie != nil:
 		req.AddCookie(c.sessionCookie)
 	case requireAuth:
+		// this should not happen, because we use RequiresLogin() to check
+		// if the user is logged in beforehand
 		return nil, fmt.Errorf("you need to log in to run this command")
 	}
 
@@ -274,4 +278,58 @@ func DecodePrice(invoice string) (uint64, error) {
 	}
 
 	return uint64(msat / 1000), nil
+}
+
+// RequiresLogin checks for a valid API key and verifies it against
+// the /authorize endpoint.
+func RequiresLogin() error {
+	store := store.GetStore()
+	apiKeys, err := store.GetEnabledAPIKeys()
+	if err != nil {
+		return fmt.Errorf("failed to retrieve API keys: %w", err)
+	}
+
+	for _, apiKey := range apiKeys {
+		resp, err := verifyAPIKey(apiKey.Key)
+		if err != nil {
+			return fmt.Errorf("failed to verify API key: %w", err)
+		}
+
+		if resp.StatusCode >= 200 && resp.StatusCode < 400 {
+			return nil
+		}
+		store.DisableAPIKey(apiKey.ID)
+	}
+
+	return fmt.Errorf("no valid API keys found")
+}
+
+// verifyAPIKey makes a request to the /authorize endpoint to check if the API
+// key is still valid.
+func verifyAPIKey(key string) (*http.Response, error) {
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return nil, fmt.Errorf("unable to create http client: %w", err)
+	}
+
+	// using list apikeys to verify, ideally change to a custom authorize endpoint
+	url := fmt.Sprintf("%s%s", cfg.Domain, "/v0/auth/apikeys")
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		slog.Debug("Failed to create request", "error", err, "key", key)
+		return nil, err
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", key))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		slog.Debug("Failed to execute authorize request", "error", err,
+			"key", key)
+
+		return nil, err
+	}
+
+	return resp, nil
 }

--- a/client/client.go
+++ b/client/client.go
@@ -50,19 +50,24 @@ func (c *HttpClient) SetSessionCookie(sessionCookie *http.Cookie) {
 	c.sessionCookie = sessionCookie
 }
 
-func (c *HttpClient) ExecuteRequest(method, path string, body []byte) (*http.Response, error) {
+func (c *HttpClient) ExecuteRequest(method, path string,
+	body []byte) (*http.Response, error) {
+
 	url := fmt.Sprintf("%s%s", c.domain, path)
 	req, err := http.NewRequest(method, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create request: %w", err)
 	}
 
-	if c.apiKey != "" {
+	// do not require auth for signup / login
+	requireAuth := !strings.Contains(path, "/signup") && !strings.Contains(path, "/login")
+	switch {
+	case c.apiKey != "":
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.apiKey))
-	}
-
-	if c.sessionCookie != nil {
+	case c.sessionCookie != nil:
 		req.AddCookie(c.sessionCookie)
+	case requireAuth:
+		return nil, fmt.Errorf("you need to log in to run this command")
 	}
 
 	if body != nil {

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -24,7 +24,7 @@ func main() {
 
 	fewsatsDir := filepath.Join(homeDir, ".fewsats")
 	if _, err := os.Stat(fewsatsDir); os.IsNotExist(err) {
-		err = os.Mkdir(fewsatsDir, 0755) // Create the directory with read/write/execute permissions for the owner
+		err = os.Mkdir(fewsatsDir, 0755)
 		if err != nil {
 			log.Fatal("Failed to create .fewsats directory:", err)
 		}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -2,18 +2,45 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"log/slog"
 	"os"
+	"path/filepath"
 
 	"github.com/fewsats/fewsatscli/account"
 	"github.com/fewsats/fewsatscli/apikeys"
 	"github.com/fewsats/fewsatscli/config"
 	"github.com/fewsats/fewsatscli/storage"
+	"github.com/fewsats/fewsatscli/store"
 	"github.com/fewsats/fewsatscli/version"
 	"github.com/urfave/cli/v2"
 )
 
 func main() {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		log.Fatal("Failed to get user home directory:", err)
+	}
+
+	fewsatsDir := filepath.Join(homeDir, ".fewsats")
+	if _, err := os.Stat(fewsatsDir); os.IsNotExist(err) {
+		err = os.Mkdir(fewsatsDir, 0755) // Create the directory with read/write/execute permissions for the owner
+		if err != nil {
+			log.Fatal("Failed to create .fewsats directory:", err)
+		}
+	}
+
+	dbPath := filepath.Join(fewsatsDir, "fewsats.db")
+	store, err := store.NewStore(dbPath)
+	if err != nil {
+		log.Fatal("Failed to create store:", err)
+	}
+
+	err = store.InitSchema()
+	if err != nil {
+		log.Fatal("Failed to initialize database schema:", err)
+	}
+
 	app := &cli.App{
 		Name:                 "Fewsats CLI",
 		Usage:                "Interact with the Fewsats Platform.",
@@ -46,7 +73,7 @@ func main() {
 		},
 	}
 
-	err := app.Run(os.Args)
+	err = app.Run(os.Args)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"strings"
 
 	"github.com/joho/godotenv"
 )
@@ -16,7 +17,10 @@ const (
 )
 
 var (
-	loadedConfig *Config
+	loadedConfig  *Config
+	defaultConfig = map[string]string{
+		"LOG_LEVEL": "debug",
+	}
 )
 
 type Config struct {
@@ -24,6 +28,15 @@ type Config struct {
 	Domain    string
 	AlbyToken string
 	LogLevel  string
+	ConfigDir string
+}
+
+func getDefaultConfigContent() string {
+	var lines []string
+	for key, value := range defaultConfig {
+		lines = append(lines, fmt.Sprintf(`%s="%s"`, key, value))
+	}
+	return strings.Join(lines, "\n")
 }
 
 func GetConfig() (*Config, error) {
@@ -37,21 +50,29 @@ func GetConfig() (*Config, error) {
 		return nil, fmt.Errorf("unable to get current OS user: %w", err)
 	}
 
-	// Construct the path to the .fewsatscli file
-	filepath := filepath.Join(usr.HomeDir, ".fewsatscli")
+	// Construct the path to the config file (~/.fewsats/config)
+	configDir := filepath.Join(usr.HomeDir, ".fewsats")
+	configFilePath := filepath.Join(configDir, "config")
 
-	// Check if the file exists
-	if _, err := os.Stat(filepath); err == nil {
-		slog.Debug("Loading .fewsatscli file...\n")
-
-		// If the file exists, load it
-		err = godotenv.Load(filepath)
-		if err != nil {
-			return nil, fmt.Errorf("unable to load .fewsatscli file: %w", err)
+	// Check if the config file exists
+	if _, err := os.Stat(configFilePath); os.IsNotExist(err) {
+		slog.Debug("Config file not found. Creating default config file...\n")
+		defaultContent := getDefaultConfigContent()
+		// Create the file with default content if it does not exist
+		if err := os.WriteFile(configFilePath, []byte(defaultContent), 0644); err != nil {
+			return nil, fmt.Errorf("failed to create default config file: %w", err)
 		}
+	} else if err != nil {
+		return nil, fmt.Errorf("failed to check config file: %w", err)
 	}
 
-	// Set global config from .fewsatscli file
+	// Load the config file
+	err = godotenv.Load(configFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to load config file: %w", err)
+	}
+
+	// Set global config from file
 	domain, exists := os.LookupEnv("DOMAIN")
 	if !exists {
 		domain = baseURL
@@ -69,6 +90,7 @@ func GetConfig() (*Config, error) {
 		Domain:    domain,
 		AlbyToken: albyToken,
 		LogLevel:  logLevel,
+		ConfigDir: configDir,
 	}
 
 	return loadedConfig, nil

--- a/config/config.go
+++ b/config/config.go
@@ -19,7 +19,7 @@ const (
 var (
 	loadedConfig  *Config
 	defaultConfig = map[string]string{
-		"LOG_LEVEL": "debug",
+		"LOG_LEVEL": "info",
 	}
 )
 

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,10 @@ go 1.21.4
 
 require (
 	github.com/btcsuite/btcd v0.23.5-0.20230905170901-80f5a0ffdf36
+	github.com/jmoiron/sqlx v1.4.0
 	github.com/joho/godotenv v1.5.1
 	github.com/lightningnetwork/lnd v0.17.3-beta
+	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/urfave/cli/v2 v2.27.1
 	golang.org/x/term v0.19.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
+filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da h1:KjTM2ks9d14ZYCvmHS9iAKVt9AyzRSqNU1qabPih5BY=
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da/go.mod h1:eHEWzANqSiWQsof+nXEI9bUVUyV6F53Fp89EuCh2EAA=
 github.com/aead/siphash v1.0.1 h1:FwHfE/T45KPKYuuSAKyyvE+oPWcaQ+CUmFW0bPlM+kg=
@@ -87,6 +89,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/go-errors/errors v1.0.1 h1:LUHzmkK3GUKUrL/1gfBUxAHzcev3apQlezX/+O7ma6w=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
+github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpvNJ1Y=
+github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQAYs=
@@ -139,6 +143,8 @@ github.com/jackc/pgx/v4 v4.18.1/go.mod h1:FydWkUyadDmdNH/mHnGob881GawxeEm7TcMCzk
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/jmoiron/sqlx v1.4.0 h1:1PLqN7S1UYp5t4SrVVnt4nUVNemrDAtxlulVe+Qgm3o=
+github.com/jmoiron/sqlx v1.4.0/go.mod h1:ZrZ7UsYB/weZdl2Bxg6jCRO9c3YHl8r3ahlKmRT4JLY=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jonboulle/clockwork v0.2.2 h1:UOGuzwb1PwsrDAObMuhUnj0p5ULPj8V/xJ7Kx9qUBdQ=
@@ -159,8 +165,8 @@ github.com/klauspost/pgzip v1.2.5/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQ
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/lib/pq v1.10.3 h1:v9QZf2Sn6AmjXtQeFpdoq/eaNtYP6IN+7lcrygsIAtg=
-github.com/lib/pq v1.10.3/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf h1:HZKvJUHlcXI/f/O0Avg7t8sqkPo78HFzjmeYFl6DPnc=
 github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf/go.mod h1:vxmQPeIQxPf6Jf9rM8R+B4rKBqLA2AjttNxkFBL2Plk=
 github.com/lightninglabs/neutrino v0.16.0 h1:YNTQG32fPR/Zg0vvJVI65OBH8l3U18LSXXtX91hx0q0=
@@ -190,6 +196,8 @@ github.com/ltcsuite/ltcd v0.0.0-20190101042124-f37f8bf35796 h1:sjOGyegMIhvgfq5oa
 github.com/ltcsuite/ltcd v0.0.0-20190101042124-f37f8bf35796/go.mod h1:3p7ZTf9V1sNPI5H8P3NkTFF4LuwMdPl2DodF60qAKqY=
 github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
+github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mholt/archiver/v3 v3.5.0 h1:nE8gZIrw66cu4osS/U7UW7YDuGMHssxKutU8IfWxwWE=

--- a/sample.env
+++ b/sample.env
@@ -1,4 +1,3 @@
 DOMAIN="http://localhost:8080"
-APIKEY="user-apikey"
 ALBY_TOKEN="alby-token"
 LOG_LEVEL="debug"

--- a/storage/upload.go
+++ b/storage/upload.go
@@ -67,6 +67,11 @@ var uploadFileCommand = &cli.Command{
 
 // uploadFile uploads a file to the storage service.
 func uploadFile(c *cli.Context) error {
+	err := client.RequiresLogin()
+	if err != nil {
+		return cli.Exit("You need to log in to run this command.", 1)
+	}
+
 	cfg, err := config.GetConfig()
 	if err != nil {
 		slog.Debug(

--- a/store/models.go
+++ b/store/models.go
@@ -4,6 +4,9 @@ import "time"
 
 type APIKey struct {
 	ID        uint64     `db:"id"`
-	HiddenKey string     `db:"key"`
+	Key       string     `db:"key"`
+	HiddenKey string     `db:"hidden_key"`
+	UserID    int64      `db:"user_id"`
 	ExpiresAt *time.Time `db:"expires_at"`
+	Enabled   bool       `db:"enabled"`
 }

--- a/store/models.go
+++ b/store/models.go
@@ -1,0 +1,9 @@
+package store
+
+import "time"
+
+type APIKey struct {
+	ID        uint64     `db:"id"`
+	HiddenKey string     `db:"key"`
+	ExpiresAt *time.Time `db:"expires_at"`
+}

--- a/store/store.go
+++ b/store/store.go
@@ -27,7 +27,6 @@ func GetStore() *Store {
 		homeDir, _ := os.UserHomeDir()
 		dbPath := filepath.Join(homeDir, ".fewsats", "fewsats.db")
 		instance, _ = NewStore(dbPath)
-		instance.InitSchema()
 	})
 	return instance
 }
@@ -45,22 +44,25 @@ func (s *Store) InitSchema() error {
 	CREATE TABLE IF NOT EXISTS api_keys (
 		id INTEGER PRIMARY KEY AUTOINCREMENT,
 		key TEXT NOT NULL,
-		expires_at DATETIME NOT NULL
+		expires_at DATETIME NOT NULL,
+		user_id INTEGER NOT NULL,
+		enabled BOOLEAN NOT NULL DEFAULT 1
 	);`
 	_, err := s.db.Exec(schema)
 	return err
 }
 
-func (s *Store) InsertAPIKey(key string, expiresAt time.Time) (int64, error) {
-	result, err := s.db.Exec("INSERT INTO api_keys (key, expires_at) VALUES (?, ?)", key, expiresAt)
+func (s *Store) InsertAPIKey(key string, expiresAt time.Time, userID int64) (int64, error) {
+	result, err := s.db.Exec("INSERT INTO api_keys (key, expires_at, user_id, enabled) VALUES (?, ?, ?, 1)", key, expiresAt, userID)
 	if err != nil {
 		return 0, err
 	}
 	return result.LastInsertId()
 }
+
 func (s *Store) GetAPIKey() (string, error) {
 	var apiKey string
-	err := s.db.Get(&apiKey, "SELECT key FROM api_keys WHERE expires_at > CURRENT_TIMESTAMP LIMIT 1")
+	err := s.db.Get(&apiKey, "SELECT key FROM api_keys WHERE expires_at > CURRENT_TIMESTAMP AND enabled = 1 LIMIT 1")
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return "", nil // Return an empty string and no error if no rows are found
@@ -68,4 +70,17 @@ func (s *Store) GetAPIKey() (string, error) {
 		return "", err
 	}
 	return apiKey, nil
+}
+
+// GetEnabledAPIKeys retrieves all enabled API keys that have not expired.
+func (s *Store) GetEnabledAPIKeys() ([]APIKey, error) {
+	var apiKeys []APIKey
+	err := s.db.Select(&apiKeys, "SELECT * FROM api_keys WHERE expires_at > CURRENT_TIMESTAMP AND enabled = 1")
+	return apiKeys, err
+}
+
+// DisableAPIKey sets the enabled field of an API key to false.
+func (s *Store) DisableAPIKey(id uint64) error {
+	_, err := s.db.Exec("UPDATE api_keys SET enabled = 0 WHERE id = ?", id)
+	return err
 }

--- a/store/store.go
+++ b/store/store.go
@@ -1,0 +1,71 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"database/sql"
+
+	"github.com/jmoiron/sqlx"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+var (
+	instance *Store
+	once     sync.Once
+)
+
+type Store struct {
+	db *sqlx.DB
+}
+
+func GetStore() *Store {
+	once.Do(func() {
+		homeDir, _ := os.UserHomeDir()
+		dbPath := filepath.Join(homeDir, ".fewsats", "fewsats.db")
+		instance, _ = NewStore(dbPath)
+		instance.InitSchema()
+	})
+	return instance
+}
+
+func NewStore(dbPath string) (*Store, error) {
+	db, err := sqlx.Connect("sqlite3", dbPath)
+	if err != nil {
+		return nil, err
+	}
+	return &Store{db: db}, nil
+}
+
+func (s *Store) InitSchema() error {
+	schema := `
+	CREATE TABLE IF NOT EXISTS api_keys (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		key TEXT NOT NULL,
+		expires_at DATETIME NOT NULL
+	);`
+	_, err := s.db.Exec(schema)
+	return err
+}
+
+func (s *Store) InsertAPIKey(key string, expiresAt time.Time) (int64, error) {
+	result, err := s.db.Exec("INSERT INTO api_keys (key, expires_at) VALUES (?, ?)", key, expiresAt)
+	if err != nil {
+		return 0, err
+	}
+	return result.LastInsertId()
+}
+func (s *Store) GetAPIKey() (string, error) {
+	var apiKey string
+	err := s.db.Get(&apiKey, "SELECT key FROM api_keys WHERE expires_at > CURRENT_TIMESTAMP LIMIT 1")
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return "", nil // Return an empty string and no error if no rows are found
+		}
+		return "", err
+	}
+	return apiKey, nil
+}


### PR DESCRIPTION
Changes 
- SQLite database at `.fewsats/fewsats.db`
- Moved `.fewsatscli` file to `.fewsats/config`
- Auto-creating SQL & config when running CLI
- HTTP client deals with "auth" as follows:
  - Add APIKey stored in SQL to request, if not available
  - Add sessionCookie (from a login), if not available
  - Fail the request (except for signup / login paths)
- Created schema initialization and API key insertion functions in the store

**Latest update**
- I've added back enabled status because it's very convenient to debug, we can hide it from fewsatscli, but I think it looks good. Anthropic shows both enabled/disabled. 
- I've added the userID field to the DB. The CLI supports creating multiple users & logging them in. However, their keys will all be mixed up. I think it's better to store the userID so at least we know whose key is whose.
- Added `RequiresLogin` method to `client`. The method retrieves all SQLite keys. If there are no keys it fails. Otherwise for each `enabled` key in SQLite
    1. Try to hit the `apikeys list` endpoint (we should create a new "authorize" endpoint in the future)
    2. If status 2xx or 3xx => return OK, and break the loop (no more keys are validated)
    3. If status != 2xx or 3xx => return error and disable key
    4. On any error, just return error (but don't disable the key)

Related PR to return userID & enabled fields again: https://github.com/Fewsats/platform/pull/14