### PR TITLE
multi: list commands using json output

### DIFF
--- a/apikeys/list.go
+++ b/apikeys/list.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"os"
-	"text/tabwriter"
 
 	// Added to support time.Time in APIKey struct
 	"github.com/fewsats/fewsatscli/client"
@@ -18,15 +16,6 @@ var listCommand = &cli.Command{
 	Name:   "list",
 	Usage:  "List all API keys.",
 	Action: listAPIKeys,
-}
-
-func printKeys(keys []store.APIKey) {
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', tabwriter.Debug)
-	fmt.Fprintln(w, "ID\t Key\t ExpiresAt\t Enabled")
-	for _, key := range keys {
-		fmt.Fprintf(w, "%d\t %s\t %s\t %t\n", key.ID, key.HiddenKey, key.ExpiresAt, key.Enabled)
-	}
-	w.Flush()
 }
 
 func listAPIKeys(c *cli.Context) error {
@@ -62,7 +51,12 @@ func listAPIKeys(c *cli.Context) error {
 		return cli.Exit("Failed to decode API keys.", 1)
 	}
 
-	printKeys(response.Keys)
+	jsonOutput, err := json.MarshalIndent(response, "", "  ")
+	if err != nil {
+		return cli.Exit("Failed to marshal JSON.", 1)
+	}
+
+	fmt.Println(string(jsonOutput))
 
 	return nil
 }

--- a/storage/list.go
+++ b/storage/list.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"os"
-	"text/tabwriter"
 	"time"
 
 	"github.com/fewsats/fewsatscli/client"
@@ -30,17 +28,6 @@ var listCommand = &cli.Command{
 	Name:   "list",
 	Usage:  "List all files.",
 	Action: listFiles,
-}
-
-func printFiles(files []File) {
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', tabwriter.Debug)
-	fmt.Fprintln(w, "ID\t Name\t Updated At\t URL")
-	for _, file := range files {
-		updatedAt := file.UpdatedAt.Local().Format("2006-01-02 15:04")
-		fmt.Fprintf(w, "%s\t %s\t %s\t %s\n",
-			file.ExternalID, file.Name, updatedAt, file.StorageURL)
-	}
-	w.Flush()
 }
 
 func listFiles(c *cli.Context) error {
@@ -74,6 +61,12 @@ func listFiles(c *cli.Context) error {
 		return cli.Exit("Failed to decode files.", 1)
 	}
 
-	printFiles(response.Files)
+	jsonOutput, err := json.MarshalIndent(response, "", "  ")
+	if err != nil {
+		return cli.Exit("Failed to marshal JSON.", 1)
+	}
+
+	fmt.Println(string(jsonOutput))
+
 	return nil
 }


### PR DESCRIPTION
Migrated both list apikeys and storage commands to use JSON output like the rest. Eg.

```
❯fewsatscli storage list

{
  "files": [
    {
      "external_id": "eeaf283a-9bc9X4e07-a1ba-7cb48c82be5e",
      "name": "minsky.pdf",
      "description": "Steps Towards Artificial Intelligence paper by Marvin Minsky 1961",
      "size": 0,
      "extension": ".pdf",
      "mime_type": "application/pdf",
      "storage_url": "XXXX,
      "price_in_usd_cents": 5,
      "created_at": "2024-05-08T14:43:05.319707Z",
      "updated_at": "2024-05-08T14:43:05.319707Z"
    }
  ]
}
``` 
and
```
fewsatscli apikeys list
{
  "keys": [
    {
      "ID": 1,
      "Key": "",
      "HiddenKey": "********",
      "UserID": 1,
      "ExpiresAt": "2024-05-30T09:11:37.484578Z",
      "Enabled": false
    }
  ]
}
```
